### PR TITLE
Updated version of function "D_period_function". Two new parameters "…

### DIFF
--- a/trachoma/trachoma_functions.py
+++ b/trachoma/trachoma_functions.py
@@ -217,7 +217,7 @@ def D_period_function(Ind_D_period_base, No_Inf, params, Age):
     '''
     ag = 0.00179
     aq = 0.0368
-    T_ID = np.round( params['min_D'] + ( Ind_D_period_base - params['min_D'] * np.exp( -aq * ( No_Inf - 1) -ag * ( Age-1 ) ) ) )
+    T_ID = np.round( params['min_D'] + ( Ind_D_period_base - params['min_D'] ) * np.exp( -aq * ( No_Inf-1 ) -ag * Age ) )
 
     return T_ID
 

--- a/trachoma/trachoma_functions.py
+++ b/trachoma/trachoma_functions.py
@@ -215,10 +215,10 @@ def D_period_function(Ind_D_period_base, No_Inf, params, Age):
     '''
     Function to give duration of disease only period.
     '''
+    ag = 0.00179
+    aq = 0.0368
+    T_ID = np.round( params['min_D'] + ( Ind_D_period_base - params['min_D'] * np.exp( -aq * ( No_Inf - 1) -ag * ( Age-1 ) ) ) )
 
-    ag = params['ag']
-    minAq = params['min_D']+(Ind_D_period_base - params['min_D']) * params['prop_age']
-    T_ID = np.round((Ind_D_period_base - minAq) * np.exp(-params['dis_red'] * (No_Inf-1)) + (minAq-params['min_D']) * np.exp(-ag*(Age-1)) + params['min_D'])
     return T_ID
 
 def bacterialLoad(No_Inf):


### PR DESCRIPTION
…ag" and "aq" (decay coefficients for age-related and acquired immunity-related changes in disease duration). This function no longer calls "dis_red" which is not needed in parameters now, or "prop_age" which had been previously fixed at 0, but is now not needed.

Things to do: Add "ag" and "aq" to parameters, removed "dis_red" and "prop_age"

(Then need to tiny up i.e. change within function ag<-params['ag'], aq<-params['aq])